### PR TITLE
Add --log-states flag for logging game states during replay

### DIFF
--- a/source/simulation2/Simulation2.cpp
+++ b/source/simulation2/Simulation2.cpp
@@ -400,15 +400,15 @@ void CSimulation2Impl::Update(int turnLength, const std::vector<SimulationComman
 			ENSURE(m_ComponentManager.ComputeStateHash(primaryStateBefore.hash, false));
 	}
 
-    const bool LOG_TRAJECTORY = true;
-    if (LOG_TRAJECTORY) {
+    const bool LOG_STATES = g_args.Has("log-states");
+    if (LOG_STATES) {
         // TODO: Log the state to a file
 
 		CmpPtr<ICmpAIInterface> cmpAIInterface(m_SimContext.GetSystemEntity());
         JSContext* cx = scriptInterface.GetContext();
 		JS::RootedValue state(cx);
 		cmpAIInterface->GetFullRepresentation(&state, true);
-        std::cout << m_TurnNumber << " " << scriptInterface.StringifyJSON(&state, false) << std::endl;
+        std::cout << "state " << m_TurnNumber << " " << scriptInterface.StringifyJSON(&state, false) << std::endl;
     }
 
 	UpdateComponents(m_SimContext, turnLengthFixed, commands);

--- a/source/simulation2/Simulation2.cpp
+++ b/source/simulation2/Simulation2.cpp
@@ -27,6 +27,7 @@
 #include "simulation2/system/ParamNode.h"
 #include "simulation2/system/SimContext.h"
 #include "simulation2/components/ICmpAIManager.h"
+#include "simulation2/components/ICmpAIInterface.h"
 #include "simulation2/components/ICmpCommandQueue.h"
 #include "simulation2/components/ICmpTemplateManager.h"
 
@@ -398,6 +399,17 @@ void CSimulation2Impl::Update(int turnLength, const std::vector<SimulationComman
 		if (serializationTestHash)
 			ENSURE(m_ComponentManager.ComputeStateHash(primaryStateBefore.hash, false));
 	}
+
+    const bool LOG_TRAJECTORY = true;
+    if (LOG_TRAJECTORY) {
+        // TODO: Log the state to a file
+
+		CmpPtr<ICmpAIInterface> cmpAIInterface(m_SimContext.GetSystemEntity());
+        JSContext* cx = scriptInterface.GetContext();
+		JS::RootedValue state(cx);
+		cmpAIInterface->GetFullRepresentation(&state, true);
+        std::cout << "State: " << scriptInterface.StringifyJSON(&state, false) << std::endl;
+    }
 
 	UpdateComponents(m_SimContext, turnLengthFixed, commands);
 

--- a/source/simulation2/Simulation2.cpp
+++ b/source/simulation2/Simulation2.cpp
@@ -408,7 +408,7 @@ void CSimulation2Impl::Update(int turnLength, const std::vector<SimulationComman
         JSContext* cx = scriptInterface.GetContext();
 		JS::RootedValue state(cx);
 		cmpAIInterface->GetFullRepresentation(&state, true);
-        std::cout << "State: " << scriptInterface.StringifyJSON(&state, false) << std::endl;
+        std::cout << m_TurnNumber << " " << scriptInterface.StringifyJSON(&state, false) << std::endl;
     }
 
 	UpdateComponents(m_SimContext, turnLengthFixed, commands);

--- a/source/simulation2/Simulation2.cpp
+++ b/source/simulation2/Simulation2.cpp
@@ -400,15 +400,13 @@ void CSimulation2Impl::Update(int turnLength, const std::vector<SimulationComman
 			ENSURE(m_ComponentManager.ComputeStateHash(primaryStateBefore.hash, false));
 	}
 
-    const bool LOG_STATES = g_args.Has("log-states");
-    if (LOG_STATES) {
-        // TODO: Log the state to a file
-
+	const bool LOG_STATES = g_args.Has("log-states");
+	if (LOG_STATES) {
 		CmpPtr<ICmpAIInterface> cmpAIInterface(m_SimContext.GetSystemEntity());
-        JSContext* cx = scriptInterface.GetContext();
+		JSContext* cx = scriptInterface.GetContext();
 		JS::RootedValue state(cx);
 		cmpAIInterface->GetFullRepresentation(&state, true);
-        std::cout << "state " << m_TurnNumber << " " << scriptInterface.StringifyJSON(&state, false) << std::endl;
+		std::cout << "state " << m_TurnNumber << " " << scriptInterface.StringifyJSON(&state, false) << std::endl;
     }
 
 	UpdateComponents(m_SimContext, turnLengthFixed, commands);

--- a/source/simulation2/Simulation2.h
+++ b/source/simulation2/Simulation2.h
@@ -21,6 +21,7 @@
 #include "simulation2/system/CmpPtr.h"
 #include "simulation2/system/Components.h"
 #include "simulation2/helpers/SimulationCommand.h"
+#include "ps/GameSetup/CmdLineArgs.h"
 #include "scriptinterface/ScriptVal.h"
 
 #include "lib/file/vfs/vfs_path.h"
@@ -39,6 +40,7 @@ class CMessage;
 class SceneCollector;
 class CFrustum;
 class ScriptRuntime;
+extern CmdLineArgs g_args;
 
 /**
  * Public API for simulation system.


### PR DESCRIPTION
This is useful for imitation learning. Actions are not included as they can be retrieved from the commands.txt file in the replay for the given directory.